### PR TITLE
Version number in print_help()

### DIFF
--- a/ipv6mon.c
+++ b/ipv6mon.c
@@ -884,7 +884,7 @@ void usage(void){
  * Prints help information for the na-attack tool
  */
 void print_help(void){
-	puts( "ipv6mon version 1.0\nAn IPv6 Address Monitoring tool\n");
+	printf( "ipv6mon version %.1f\nAn IPv6 Address Monitoring tool\n",IP6MON_VERSION);
 	usage();
     
 	puts("\nOPTIONS:\n"

--- a/ipv6mon.c
+++ b/ipv6mon.c
@@ -884,7 +884,7 @@ void usage(void){
  * Prints help information for the na-attack tool
  */
 void print_help(void){
-	puts( "ipv6mon version 0.2\nAn IPv6 Address Monitoring tool\n");
+	puts( "ipv6mon version 1.0\nAn IPv6 Address Monitoring tool\n");
 	usage();
     
 	puts("\nOPTIONS:\n"

--- a/ipv6mon.h
+++ b/ipv6mon.h
@@ -3,6 +3,8 @@
  *
  */
 
+#define IP6MON_VERSION	1.0
+
 #define LUI		long unsigned int
 
 #define BUFFER_SIZE	65556


### PR DESCRIPTION
The version number printed by print_help() is incorrect.  I've defined a constant, IP6MON_VERSION, in ipv6mon.h to store the version number and modified print_help() to use the constant.